### PR TITLE
Update run and event headers to CORSIKA version 7.8

### DIFF
--- a/corsikaio/subblocks/event_end.py
+++ b/corsikaio/subblocks/event_end.py
@@ -60,6 +60,7 @@ event_end_fields[7.4] = event_end_fields_7x
 event_end_fields[7.5] = event_end_fields_7x
 event_end_fields[7.6] = event_end_fields_7x
 event_end_fields[7.7] = event_end_fields_7x
+event_end_fields[7.8] = event_end_fields_7x
 
 event_end_types = defaultdict(warn_dtype)
 event_end_types[6.5] = event_end_dtype_65
@@ -67,6 +68,7 @@ event_end_types[7.4] = event_end_dtype_7x
 event_end_types[7.5] = event_end_dtype_7x
 event_end_types[7.6] = event_end_dtype_7x
 event_end_types[7.7] = event_end_dtype_7x
+event_end_types[7.8] = event_end_dtype_7x
 
 event_end_thin_types = defaultdict(warn_dtype)
 event_end_thin_types[6.5] = event_end_thin_dtype_65
@@ -74,3 +76,4 @@ event_end_thin_types[7.4] = event_end_thin_dtype_7x
 event_end_thin_types[7.5] = event_end_thin_dtype_7x
 event_end_thin_types[7.6] = event_end_thin_dtype_7x
 event_end_thin_types[7.7] = event_end_thin_dtype_7x
+event_end_thin_types[7.8] = event_end_thin_dtype_7x

--- a/corsikaio/subblocks/event_header.py
+++ b/corsikaio/subblocks/event_header.py
@@ -126,12 +126,25 @@ event_header_fields_75 = event_header_fields_74 + [
 event_header_fields_76 = event_header_fields_75.copy()
 event_header_fields_77 = event_header_fields_76.copy()
 
+event_header_fields_78 = event_header_fields_77 + [
+    Field(223, "coast_multi_thin_index"),
+    Field(224, "coast_multi_thin_flag"),
+    Field(225, "inclined_observation_plane_x", unit="cm"),
+    Field(226, "inclined_observation_plane_y", unit="cm"),
+    Field(227, "inclined_observation_plane_z", unit="cm"),
+    Field(228, "inclined_observation_plane_theta", unit="rad"),
+    Field(229, "inclined_observation_plane_phi", unit="rad"),
+    Field(230, "inclined_observation_plane_depth"),
+    Field(231, "fluka_version"),
+]
+
 event_header_dtype_65xxx = build_dtype(event_header_fields_65)
 event_header_dtype_73xxx = build_dtype(event_header_fields_73)
 event_header_dtype_74xxx = build_dtype(event_header_fields_74)
 event_header_dtype_75xxx = build_dtype(event_header_fields_75)
 event_header_dtype_76xxx = build_dtype(event_header_fields_76)
 event_header_dtype_77xxx = build_dtype(event_header_fields_77)
+event_header_dtype_78xxx = build_dtype(event_header_fields_78)
 
 event_header_thin_dtype_65xxx = build_dtype(event_header_fields_65, itemsize = 4 * 312)
 event_header_thin_dtype_73xxx = build_dtype(event_header_fields_73, itemsize = 4 * 312)
@@ -139,6 +152,7 @@ event_header_thin_dtype_74xxx = build_dtype(event_header_fields_74, itemsize = 4
 event_header_thin_dtype_75xxx = build_dtype(event_header_fields_75, itemsize = 4 * 312)
 event_header_thin_dtype_76xxx = build_dtype(event_header_fields_76, itemsize = 4 * 312)
 event_header_thin_dtype_77xxx = build_dtype(event_header_fields_77, itemsize = 4 * 312)
+event_header_thin_dtype_78xxx = build_dtype(event_header_fields_78, itemsize = 4 * 312)
 
 def warn_dtype():
     warnings.warn("Version unknown, using event header dtype definition of version 7.7XXX")
@@ -159,6 +173,7 @@ event_header_fields[7.4] = event_header_fields_74
 event_header_fields[7.5] = event_header_fields_75
 event_header_fields[7.6] = event_header_fields_76
 event_header_fields[7.7] = event_header_fields_77
+event_header_fields[7.8] = event_header_fields_78
 
 event_header_types = defaultdict(warn_dtype)
 event_header_types[6.5] = event_header_dtype_65xxx
@@ -166,7 +181,8 @@ event_header_types[7.3] = event_header_dtype_73xxx
 event_header_types[7.4] = event_header_dtype_74xxx
 event_header_types[7.5] = event_header_dtype_75xxx
 event_header_types[7.6] = event_header_dtype_76xxx
-event_header_types[7.7] = event_header_dtype_76xxx
+event_header_types[7.7] = event_header_dtype_77xxx
+event_header_types[7.8] = event_header_dtype_78xxx
 
 event_header_thin_types = defaultdict(warn_dtype_thin)
 event_header_thin_types[6.5] = event_header_thin_dtype_65xxx
@@ -174,4 +190,5 @@ event_header_thin_types[7.3] = event_header_thin_dtype_73xxx
 event_header_thin_types[7.4] = event_header_thin_dtype_74xxx
 event_header_thin_types[7.5] = event_header_thin_dtype_75xxx
 event_header_thin_types[7.6] = event_header_thin_dtype_76xxx
-event_header_thin_types[7.7] = event_header_thin_dtype_76xxx
+event_header_thin_types[7.7] = event_header_thin_dtype_77xxx
+event_header_thin_types[7.8] = event_header_thin_dtype_78xxx

--- a/corsikaio/subblocks/run_header.py
+++ b/corsikaio/subblocks/run_header.py
@@ -99,6 +99,7 @@ run_header_fields[7.4] = run_header_fields_7x
 run_header_fields[7.5] = run_header_fields_7x
 run_header_fields[7.6] = run_header_fields_7x
 run_header_fields[7.7] = run_header_fields_7x
+run_header_fields[7.8] = run_header_fields_7x
 
 run_header_types = defaultdict(warn_dtype)
 run_header_types[6.5] = run_header_dtype_65
@@ -106,6 +107,7 @@ run_header_types[7.4] = run_header_dtype_7x
 run_header_types[7.5] = run_header_dtype_7x
 run_header_types[7.6] = run_header_dtype_7x
 run_header_types[7.7] = run_header_dtype_7x
+run_header_types[7.8] = run_header_dtype_7x
 
 run_header_thin_types = defaultdict(warn_dtype_thin)
 run_header_thin_types[6.5] = run_header_thin_dtype_65
@@ -113,3 +115,4 @@ run_header_thin_types[7.4] = run_header_thin_dtype_7x
 run_header_thin_types[7.5] = run_header_thin_dtype_7x
 run_header_thin_types[7.6] = run_header_thin_dtype_7x
 run_header_thin_types[7.7] = run_header_thin_dtype_7x
+run_header_thin_types[7.8] = run_header_thin_dtype_7x


### PR DESCRIPTION
Added run and event header entries for CORSIKA version 7.8.

Checked the manual for changes in both header headers - only the event header changed with additional fields.

Attached for convenience the changes to the event headers:

[CORSIKA_GUIDE7.8010.pdf](https://github.com/user-attachments/files/23887152/CORSIKA_GUIDE7.8010.pdf)

Also think there was a small bug in the `event_header_types` and `event_header_thin_types` assignment for 7.7.
